### PR TITLE
add serialize dto for clone in langgraph

### DIFF
--- a/gigachat-java/src/main/java/chat/giga/model/completion/ChatFunction.java
+++ b/gigachat-java/src/main/java/chat/giga/model/completion/ChatFunction.java
@@ -7,13 +7,20 @@ import lombok.Value;
 import lombok.experimental.Accessors;
 import lombok.extern.jackson.Jacksonized;
 
+import java.io.Serializable;
 import java.util.List;
 
 @Value
 @Builder
 @Jacksonized
 @Accessors(fluent = true)
-public class ChatFunction {
+public class ChatFunction implements Serializable {
+
+    /**
+     * Версия класса для сериализации.
+     * Изменить при несовместимых изменениях в структуре класса.
+     */
+    private static final long serialVersionUID = 1L;
 
     /**
      * Название пользовательской функции, для которой будут сгенерированы аргументы.

--- a/gigachat-java/src/main/java/chat/giga/model/completion/ChatFunctionCall.java
+++ b/gigachat-java/src/main/java/chat/giga/model/completion/ChatFunctionCall.java
@@ -7,13 +7,20 @@ import lombok.Value;
 import lombok.experimental.Accessors;
 import lombok.extern.jackson.Jacksonized;
 
+import java.io.Serializable;
 import java.util.Map;
 
 @Value
 @Builder
 @Jacksonized
 @Accessors(fluent = true)
-public class ChatFunctionCall {
+public class ChatFunctionCall implements Serializable {
+
+    /**
+     * Версия класса для сериализации.
+     * Изменить при несовместимых изменениях в структуре класса.
+     */
+    private static final long serialVersionUID = 1L;
 
     /**
      * Название функции.

--- a/gigachat-java/src/main/java/chat/giga/model/completion/ChatFunctionFewShotExample.java
+++ b/gigachat-java/src/main/java/chat/giga/model/completion/ChatFunctionFewShotExample.java
@@ -7,13 +7,20 @@ import lombok.Value;
 import lombok.experimental.Accessors;
 import lombok.extern.jackson.Jacksonized;
 
+import java.io.Serializable;
 import java.util.Map;
 
 @Value
 @Builder
 @Jacksonized
 @Accessors(fluent = true)
-public class ChatFunctionFewShotExample {
+public class ChatFunctionFewShotExample implements Serializable {
+
+    /**
+     * Версия класса для сериализации.
+     * Изменить при несовместимых изменениях в структуре класса.
+     */
+    private static final long serialVersionUID = 1L;
 
     /**
      * Запрос пользователя.

--- a/gigachat-java/src/main/java/chat/giga/model/completion/ChatFunctionParameters.java
+++ b/gigachat-java/src/main/java/chat/giga/model/completion/ChatFunctionParameters.java
@@ -7,6 +7,7 @@ import lombok.Value;
 import lombok.experimental.Accessors;
 import lombok.extern.jackson.Jacksonized;
 
+import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
 
@@ -14,7 +15,13 @@ import java.util.Map;
 @Builder
 @Jacksonized
 @Accessors(fluent = true)
-public class ChatFunctionParameters {
+public class ChatFunctionParameters implements Serializable {
+
+    /**
+     * Версия класса для сериализации.
+     * Изменить при несовместимых изменениях в структуре класса.
+     */
+    private static final long serialVersionUID = 1L;
 
     /**
      * Тип параметров функции.

--- a/gigachat-java/src/main/java/chat/giga/model/completion/ChatFunctionParametersProperty.java
+++ b/gigachat-java/src/main/java/chat/giga/model/completion/ChatFunctionParametersProperty.java
@@ -7,6 +7,7 @@ import lombok.Value;
 import lombok.experimental.Accessors;
 import lombok.extern.jackson.Jacksonized;
 
+import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
 
@@ -14,7 +15,13 @@ import java.util.Map;
 @Builder
 @Jacksonized
 @Accessors(fluent = true)
-public class ChatFunctionParametersProperty {
+public class ChatFunctionParametersProperty implements Serializable {
+
+    /**
+     * Версия класса для сериализации.
+     * Изменить при несовместимых изменениях в структуре класса.
+     */
+    private static final long serialVersionUID = 1L;
 
     /**
      * Тип аргумента функции

--- a/gigachat-java/src/main/java/chat/giga/model/completion/ChatMessage.java
+++ b/gigachat-java/src/main/java/chat/giga/model/completion/ChatMessage.java
@@ -7,13 +7,20 @@ import lombok.Value;
 import lombok.experimental.Accessors;
 import lombok.extern.jackson.Jacksonized;
 
+import java.io.Serializable;
 import java.util.List;
 
 @Value
 @Builder
 @Jacksonized
 @Accessors(fluent = true)
-public class ChatMessage {
+public class ChatMessage implements Serializable {
+
+    /**
+     * Версия класса для сериализации.
+     * Изменить при несовместимых изменениях в структуре класса.
+     */
+    private static final long serialVersionUID = 1L;
 
     /**
      * Роль автора сообщения: `system` — системный промпт, который задает роль модели, например, должна модель отвечать

--- a/gigachat-java/src/main/java/chat/giga/model/completion/Choice.java
+++ b/gigachat-java/src/main/java/chat/giga/model/completion/Choice.java
@@ -6,11 +6,19 @@ import lombok.Value;
 import lombok.experimental.Accessors;
 import lombok.extern.jackson.Jacksonized;
 
+import java.io.Serializable;
+
 @Value
 @Builder
 @Jacksonized
 @Accessors(fluent = true)
-public class Choice {
+public class Choice implements Serializable {
+
+    /**
+     * Версия класса для сериализации.
+     * Изменить при несовместимых изменениях в структуре класса.
+     */
+    private static final long serialVersionUID = 1L;
 
     @JsonProperty
     ChoiceMessage message;

--- a/gigachat-java/src/main/java/chat/giga/model/completion/ChoiceChunk.java
+++ b/gigachat-java/src/main/java/chat/giga/model/completion/ChoiceChunk.java
@@ -6,11 +6,19 @@ import lombok.Value;
 import lombok.experimental.Accessors;
 import lombok.extern.jackson.Jacksonized;
 
+import java.io.Serializable;
+
 @Value
 @Builder
 @Jacksonized
 @Accessors(fluent = true)
-public class ChoiceChunk {
+public class ChoiceChunk implements Serializable {
+
+    /**
+     * Версия класса для сериализации.
+     * Изменить при несовместимых изменениях в структуре класса.
+     */
+    private static final long serialVersionUID = 1L;
 
     @JsonProperty
     ChoiceMessageChunk delta;

--- a/gigachat-java/src/main/java/chat/giga/model/completion/ChoiceMessage.java
+++ b/gigachat-java/src/main/java/chat/giga/model/completion/ChoiceMessage.java
@@ -6,11 +6,19 @@ import lombok.Value;
 import lombok.experimental.Accessors;
 import lombok.extern.jackson.Jacksonized;
 
+import java.io.Serializable;
+
 @Value
 @Builder
 @Jacksonized
 @Accessors(fluent = true)
-public class ChoiceMessage {
+public class ChoiceMessage implements Serializable {
+
+    /**
+     * Версия класса для сериализации.
+     * Изменить при несовместимых изменениях в структуре класса.
+     */
+    private static final long serialVersionUID = 1L;
 
     /**
      * Роль автора сообщения.  Роль `function_in_progress` используется при работе встроенных функций в режиме потоковой

--- a/gigachat-java/src/main/java/chat/giga/model/completion/ChoiceMessageChunk.java
+++ b/gigachat-java/src/main/java/chat/giga/model/completion/ChoiceMessageChunk.java
@@ -6,11 +6,19 @@ import lombok.Value;
 import lombok.experimental.Accessors;
 import lombok.extern.jackson.Jacksonized;
 
+import java.io.Serializable;
+
 @Value
 @Builder
 @Jacksonized
 @Accessors(fluent = true)
-public class ChoiceMessageChunk {
+public class ChoiceMessageChunk implements Serializable {
+
+    /**
+     * Версия класса для сериализации.
+     * Изменить при несовместимых изменениях в структуре класса.
+     */
+    private static final long serialVersionUID = 1L;
 
     /**
      * Роль автора сообщения.  Роль `function_in_progress` используется при работе встроенных функций в режиме потоковой

--- a/gigachat-java/src/main/java/chat/giga/model/completion/ChoiceMessageFunctionCall.java
+++ b/gigachat-java/src/main/java/chat/giga/model/completion/ChoiceMessageFunctionCall.java
@@ -7,13 +7,20 @@ import lombok.Value;
 import lombok.experimental.Accessors;
 import lombok.extern.jackson.Jacksonized;
 
+import java.io.Serializable;
 import java.util.Map;
 
 @Value
 @Builder
 @Jacksonized
 @Accessors(fluent = true)
-public class ChoiceMessageFunctionCall {
+public class ChoiceMessageFunctionCall implements Serializable {
+
+    /**
+     * Версия класса для сериализации.
+     * Изменить при несовместимых изменениях в структуре класса.
+     */
+    private static final long serialVersionUID = 1L;
 
     /**
      * Название функции.

--- a/gigachat-java/src/main/java/chat/giga/model/completion/CompletionChunkResponse.java
+++ b/gigachat-java/src/main/java/chat/giga/model/completion/CompletionChunkResponse.java
@@ -7,13 +7,20 @@ import lombok.Value;
 import lombok.experimental.Accessors;
 import lombok.extern.jackson.Jacksonized;
 
+import java.io.Serializable;
 import java.util.List;
 
 @Value
 @Builder
 @Jacksonized
 @Accessors(fluent = true)
-public class CompletionChunkResponse {
+public class CompletionChunkResponse implements Serializable {
+
+    /**
+     * Версия класса для сериализации.
+     * Изменить при несовместимых изменениях в структуре класса.
+     */
+    private static final long serialVersionUID = 1L;
 
     /**
      * Массив ответов модели.

--- a/gigachat-java/src/main/java/chat/giga/model/completion/CompletionRequest.java
+++ b/gigachat-java/src/main/java/chat/giga/model/completion/CompletionRequest.java
@@ -10,13 +10,20 @@ import lombok.Value;
 import lombok.experimental.Accessors;
 import lombok.extern.jackson.Jacksonized;
 
+import java.io.Serializable;
 import java.util.List;
 
 @Value
 @Builder(toBuilder = true)
 @Jacksonized
 @Accessors(fluent = true)
-public class CompletionRequest {
+public class CompletionRequest implements Serializable {
+
+    /**
+     * Версия класса для сериализации.
+     * Изменить при несовместимых изменениях в структуре класса.
+     */
+    private static final long serialVersionUID = 1L;
 
     /**
      * Название модели.

--- a/gigachat-java/src/main/java/chat/giga/model/completion/CompletionResponse.java
+++ b/gigachat-java/src/main/java/chat/giga/model/completion/CompletionResponse.java
@@ -7,13 +7,20 @@ import lombok.Value;
 import lombok.experimental.Accessors;
 import lombok.extern.jackson.Jacksonized;
 
+import java.io.Serializable;
 import java.util.List;
 
 @Value
 @Builder
 @Jacksonized
 @Accessors(fluent = true)
-public class CompletionResponse {
+public class CompletionResponse implements Serializable {
+
+    /**
+     * Версия класса для сериализации.
+     * Изменить при несовместимых изменениях в структуре класса.
+     */
+    private static final long serialVersionUID = 1L;
 
     /**
      * Массив ответов модели.

--- a/gigachat-java/src/main/java/chat/giga/model/completion/Usage.java
+++ b/gigachat-java/src/main/java/chat/giga/model/completion/Usage.java
@@ -6,11 +6,19 @@ import lombok.Value;
 import lombok.experimental.Accessors;
 import lombok.extern.jackson.Jacksonized;
 
+import java.io.Serializable;
+
 @Value
 @Builder
 @Jacksonized
 @Accessors(fluent = true)
-public class Usage {
+public class Usage implements Serializable {
+
+    /**
+     * Версия класса для сериализации.
+     * Изменить при несовместимых изменениях в структуре класса.
+     */
+    private static final long serialVersionUID = 1L;
 
     /**
      * Количество токенов во входящем сообщении (роль `user`).


### PR DESCRIPTION
Added serialize dto for clone in langgraph because get error in langgraph:

.std.ObjectStreamStateSerializer : Error writing collection value
java.io.NotSerializableException: chat.giga.model.completion.ChatMessage
at java.base/java.io.ObjectOutputStream.writeObject0(ObjectOutputStream.java:1200) ~[na:na]
at java.base/java.io.ObjectOutputStream.writeObject(ObjectOutputStream.java:358) ~[na:na]
at org.bsc.langgraph4j.serializer.std.ObjectOutputWithMapper.writeObject(ObjectOutputWithMapper.java:34) ~[langgraph4j-core-jdk8-1.1.5.jar:na]
at org.bsc.langgraph4j.serializer.std.NullableObjectSerializer.writeNullableObject(NullableObjectSerializer.java:17) ~[langgraph4j-core-jdk8-1.1.5.jar:na]
at org.bsc.langgraph4j.serializer.std.ObjectStreamStateSerializer$ListSerializer.write(ObjectStreamStateSerializer.java:24) ~[langgraph4j-core-jdk8-1.1.5.jar:na]
at org.bsc.langgraph4j.serializer.std.ObjectStreamStateSerializer$ListSerializer.write(ObjectStreamStateSerializer.java:16) ~[langgraph4j-core-jdk8-1.1.5.jar:na]
at org.bsc.langgraph4j.serializer.std.ObjectOutputWithMapper.writeObject(ObjectOutputWithMapper.java:31) ~[langgraph4j-core-jdk8-1.1.5.jar:na]
at org.bsc.langgraph4j.serializer.std.NullableObjectSerializer.writeNullableObject(NullableObjectSerializer.java:17) ~[langgraph4j-core-jdk8-1.1.5.jar:na]